### PR TITLE
add popup (browser action) for controlling UI

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,9 @@
   "description": "Chestnut",
   "version": "1.0.1",
   "browser_action": {
-    "default_icon": "mushroom.png"
+    "default_icon": "mushroom.png",
+    "default_title": "The Medium is the New Tab",
+    "default_popup": "settings.html"
   },
   "chrome_url_overrides": {
     "newtab": "bg.html"

--- a/settings.css
+++ b/settings.css
@@ -1,0 +1,58 @@
+/* The switch - the box around the slider */
+.switch {
+  position: relative;
+  display: inline-block;
+  width: 60px;
+  height: 34px;
+}
+
+/* Hide default HTML checkbox */
+.switch input {display:none;}
+
+/* The slider */
+.slider {
+  position: absolute;
+  cursor: pointer;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: #ccc;
+  -webkit-transition: .4s;
+  transition: .4s;
+}
+
+.slider:before {
+  position: absolute;
+  content: "";
+  height: 26px;
+  width: 26px;
+  left: 4px;
+  bottom: 4px;
+  background-color: white;
+  -webkit-transition: .4s;
+  transition: .4s;
+}
+
+input:checked + .slider {
+  background-color: #2196F3;
+}
+
+input:focus + .slider {
+  box-shadow: 0 0 1px #2196F3;
+}
+
+input:checked + .slider:before {
+  -webkit-transform: translateX(26px);
+  -ms-transform: translateX(26px);
+  transform: translateX(26px);
+}
+
+/* Rounded sliders */
+.slider.round {
+  border-radius: 34px;
+}
+
+.slider.round:before {
+  border-radius: 50%;
+}

--- a/settings.html
+++ b/settings.html
@@ -1,0 +1,30 @@
+<html>
+<head>
+<style>
+#wrapper {
+	width: 200px;
+}
+</style>
+
+<link rel="stylesheet" href="settings.css" type="text/css" />
+
+</head>
+<body>
+
+<div id="wrapper">
+	<p>Group label:</p>
+	<label>
+	  <input type="text" id="grouplabel">
+	</label>
+	<p>Admin mode:</p>
+	<label class="switch">
+	  <input type="checkbox" id="toggleAdmin">
+	  <div class="slider"></div>
+	</label>
+</div>
+<div id="display"></div>
+
+<script src="settings.js"></script>
+
+</body>
+</html>

--- a/settings.js
+++ b/settings.js
@@ -1,0 +1,47 @@
+window.addEventListener("load", loadSettings);
+
+function loadSettings() {
+	configureToggleUI("toggleAdmin", "admin");
+}
+
+function configureToggleUI(toggle, setting) {
+	var toggleUI = document.getElementById(toggle);
+	var toggleValue = localStorage.getItem(setting);
+	toggleUI.onclick = getSettingFunction(toggle, setting);
+	refresh(toggle, toggleValue);
+}
+
+function getSettingFunction(toggle, setting) {
+	var toggle = toggle;
+	var setting = setting;
+	return function() {
+		setSetting(toggle, setting);
+	}
+}
+
+function refresh(toggle, setTo) {
+	var toggleUI = document.getElementById(toggle);
+	if (setTo === "true") {
+		toggleUI.checked = true;
+	} else {
+		toggleUI.checked = false;
+	}
+}
+
+function setSetting(toggle, setting) {
+	var settingValue = localStorage.getItem(setting);
+	var toggleUI = document.getElementById(toggle)
+	console.log("setSetting: localStorage " + setting + " value is " + settingValue);
+	if (settingValue === null) {
+		console.log("setting " + setting + " to toggle value " + toggleUI.checked);
+		localStorage.setItem(setting, toggleUI.checked);
+	} else if (settingValue === "false") {
+		console.log("settingValue is false: " + settingValue + ", setting to true");
+		localStorage.setItem(setting, true);
+		refresh(toggle, "true");
+	} else {
+		console.log("settingValue is true: " + settingValue + ", setting to false");
+		localStorage.setItem(setting, false);
+		refresh(toggle, "false");
+	}
+}


### PR DESCRIPTION
I add a popup when you click the browser icon.
This popup has a text box (for entering in your group name) and a toggle ("admin" switcher).

We can use the "admin" switcher to test out what kinds of controls people of different permission levels get. We wouldn't ship it for other people, it would just be easier for us to just hit a toggle when we're testing out UI for admins vs UI for members.
For example maybe the group admin can change the tumblr URL.
Or the group admin can invite other members to the group.
Who knows.

@LucyWilcox in case you're curious, these UI set values in local storage.